### PR TITLE
fixed selinux denials for ir led

### DIFF
--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -1,2 +1,4 @@
 type goodix_device, dev_type;
 type smartpa_device, dev_type;
+type consumer_ir_device, dev_type, mlstrustedobject;
+

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -22,3 +22,7 @@
 /dev/goodix_fp                                             u:object_r:goodix_device:s0
 /data/goodix(/.*)?                                         u:object_r:goodix_data_file:s0
 /dev/i2c_smartpa                                           u:object_r:smartpa_device:s0
+
+#ir device
+/dev/ttyHSL1                                               u:object_r:consumer_ir_device:s0
+

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,1 +1,3 @@
 allow system_server unlabeled:file unlink;
+allow system_server consumer_ir_device:chr_file { rw_file_perms };
+

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,0 +1,3 @@
+#============= untrusted_app ==============
+allow untrusted_app consumer_ir_device:chr_file { ioctl open read write };
+


### PR DESCRIPTION
These sepolicy changes allow the ir led to be accessed. I used com.tiqiaa.remote to test.