### PR TITLE
s2:obsolete  "LOCAL_COPY_HEADERS"

### DIFF
--- a/camera/QCamera2/Android.mk
+++ b/camera/QCamera2/Android.mk
@@ -5,7 +5,7 @@ LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_COPY_HEADERS_TO := qcom/camera
-LOCAL_COPY_HEADERS := QCameraFormat.h
+LOCAL_EXPORT_C_INCLUDE_DIRS := QCameraFormat.h
 
 LOCAL_SRC_FILES := \
         util/QCameraCmdThread.cpp \

--- a/camera/QCamera2/stack/mm-camera-interface/Android.mk
+++ b/camera/QCamera2/stack/mm-camera-interface/Android.mk
@@ -25,8 +25,8 @@ endif
 
 LOCAL_CFLAGS += -D_ANDROID_
 LOCAL_COPY_HEADERS_TO := mm-camera-interface
-LOCAL_COPY_HEADERS += ../common/cam_intf.h
-LOCAL_COPY_HEADERS += ../common/cam_types.h
+LOCAL_EXPORT_C_INCLUDE_DIRS += ../common/cam_intf.h
+LOCAL_EXPORT_C_INCLUDE_DIRS += ../common/cam_types.h
 
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/inc \


### PR DESCRIPTION
LOCAL_COPY_HEADERS is deprecated. Soong modules cannot use these headers, and when the VNDK is enabled, System modules in Make cannot declare or use them either.